### PR TITLE
Update 13 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.WiFi.nuspec
+++ b/MakoIoT.Device.Services.WiFi.nuspec
@@ -17,18 +17,18 @@
     <description>WiFi connectivity library for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot wifi network</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.0.35" />
-      <dependency id="nanoFramework.Logging" version="1.1.63" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.6" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.18" />
-      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.65" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
-      <dependency id="nanoFramework.System.Net" version="1.10.62" />
-      <dependency id="nanoFramework.System.Text" version="1.2.37" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.19" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.35.8833" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
+      <dependency id="nanoFramework.Logging" version="1.1.74" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.31" />
+      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.71" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.52" />
+      <dependency id="nanoFramework.System.Net" version="1.10.64" />
+      <dependency id="nanoFramework.System.Text" version="1.2.54" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>
   </metadata>
   <files>

--- a/Tests/MakoIoT.Device.Services.WiFi.Test/Extensions/DeviceBuilderExtensionsTests.cs
+++ b/Tests/MakoIoT.Device.Services.WiFi.Test/Extensions/DeviceBuilderExtensionsTests.cs
@@ -2,7 +2,7 @@
 using MakoIoT.Device.Services.WiFi.Extensions;
 using MakoIoT.Device.Services.WiFi.Test.Mocks;
 using Microsoft.Extensions.Logging;
-using nanoFramework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using nanoFramework.TestFramework;
 
 namespace MakoIoT.Device.Services.WiFi.Test.Extensions

--- a/Tests/MakoIoT.Device.Services.WiFi.Test/MakoIoT.Device.Services.WiFi.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.WiFi.Test/MakoIoT.Device.Services.WiFi.Test.nfproj
@@ -32,24 +32,28 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.40.57355\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
-    </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.0.35.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.0.35\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.85.0, Culture=neutral, PublicKeyToken=c07d481e9758c731, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.74.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.74\lib\nanoFramework.Logging.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.85\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.87.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.TestFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.2.1.87\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/MakoIoT.Device.Services.WiFi.Test/Mocks/DeviceBuilderMock.cs
+++ b/Tests/MakoIoT.Device.Services.WiFi.Test/Mocks/DeviceBuilderMock.cs
@@ -1,5 +1,5 @@
 ﻿using MakoIoT.Device.Services.Interface;
-using nanoFramework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 
 namespace MakoIoT.Device.Services.WiFi.Test.Mocks

--- a/Tests/MakoIoT.Device.Services.WiFi.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.WiFi.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.0.35" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.85" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.74" targetFramework="netnano1.0" />
+  <package id="nanoFramework.TestFramework" version="2.1.87" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.WiFi/Extensions/DeviceBuilderExtension.cs
+++ b/src/MakoIoT.Device.Services.WiFi/Extensions/DeviceBuilderExtension.cs
@@ -1,5 +1,5 @@
 ﻿using MakoIoT.Device.Services.Interface;
-using nanoFramework.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MakoIoT.Device.Services.WiFi.Extensions
 {

--- a/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
+++ b/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
@@ -26,51 +26,51 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.30.32136\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.35.8833\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.40.57355\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.0.35.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.0.35\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.74.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.74\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.15\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.2.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.65.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.65\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.71.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.71\lib\System.Device.Wifi.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.38.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.52.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.52\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.62.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.62\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.64.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.64\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading, Version=1.1.19.33722, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.19\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/MakoIoT.Device.Services.WiFi/packages.config
+++ b/src/MakoIoT.Device.Services.WiFi/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.DependencyInjection" version="1.0.35" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.65" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.62" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.35.8833" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.74" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.71" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.52" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.64" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.30.32136 to 1.0.35.8833</br>Bumps MakoIoT.Device.Services.Interface from 1.0.36.21434 to 1.0.40.57355</br>Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.15.5</br>Bumps nanoFramework.DependencyInjection from 1.0.35 to 1.1.3</br>Bumps nanoFramework.Logging from 1.1.63 to 1.1.74</br>Bumps nanoFramework.Runtime.Events from 1.11.6 to 1.11.15</br>Bumps nanoFramework.System.Collections from 1.5.18 to 1.5.31</br>Bumps nanoFramework.System.Device.Wifi from 1.5.65 to 1.5.71</br>Bumps nanoFramework.System.IO.Streams from 1.1.38 to 1.1.52</br>Bumps nanoFramework.System.Net from 1.10.62 to 1.10.64</br>Bumps nanoFramework.System.Text from 1.2.37 to 1.2.54</br>Bumps nanoFramework.System.Threading from 1.1.19 to 1.1.32</br>Bumps nanoFramework.TestFramework from 2.1.85 to 2.1.87</br>
[version update]

### :warning: This is an automated update. :warning:
