### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.WiFi.nuspec
+++ b/MakoIoT.Device.Services.WiFi.nuspec
@@ -24,7 +24,7 @@
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.71" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.52" />
-      <dependency id="nanoFramework.System.Net" version="1.10.64" />
+      <dependency id="nanoFramework.System.Net" version="1.10.68" />
       <dependency id="nanoFramework.System.Text" version="1.2.54" />
       <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>

--- a/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
+++ b/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
@@ -58,8 +58,8 @@
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.52\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.64.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.64\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.68.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.68\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.WiFi/packages.config
+++ b/src/MakoIoT.Device.Services.WiFi/packages.config
@@ -7,7 +7,7 @@
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Wifi" version="1.5.71" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.52" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.64" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.68" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.System.Net from 1.10.64 to 1.10.68</br>
[version update]

### :warning: This is an automated update. :warning:
