### PR TITLE
Update 10 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.WiFi.nuspec
+++ b/MakoIoT.Device.Services.WiFi.nuspec
@@ -18,15 +18,15 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot wifi network</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.31" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.63" />
-      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.128" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.91" />
-      <dependency id="nanoFramework.System.Net" version="1.11.37" />
-      <dependency id="nanoFramework.System.Text" version="1.3.36" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.50" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.131" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.94" />
+      <dependency id="nanoFramework.System.Net" version="1.11.42" />
+      <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
     </dependencies>
   </metadata>
   <files>

--- a/Tests/MakoIoT.Device.Services.WiFi.Test/MakoIoT.Device.Services.WiFi.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.WiFi.Test/MakoIoT.Device.Services.WiFi.Test.nfproj
@@ -34,17 +34,17 @@
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.30\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.73.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.73\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.75\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.73\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.75\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/MakoIoT.Device.Services.WiFi.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.WiFi.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.73" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.TestFramework" version="3.0.75" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
+++ b/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
@@ -29,32 +29,32 @@
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.54.39044\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.30\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.31\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.63\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.67\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.128.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.128\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.131.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.131\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.91\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.94.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.94\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.42\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading, Version=1.1.50.48563, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.50\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.Services.WiFi/packages.config
+++ b/src/MakoIoT.Device.Services.WiFi/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.54.39044" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.31" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.128" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.131" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.94" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.42" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.17.7 to 1.17.11</br>Bumps nanoFramework.DependencyInjection from 1.1.30 to 1.1.32</br>Bumps nanoFramework.Runtime.Events from 1.11.31 to 1.11.32</br>Bumps nanoFramework.System.Collections from 1.5.63 to 1.5.67</br>Bumps nanoFramework.System.Device.Wifi from 1.5.128 to 1.5.131</br>Bumps nanoFramework.System.IO.Streams from 1.1.91 to 1.1.94</br>Bumps nanoFramework.System.Net from 1.11.37 to 1.11.42</br>Bumps nanoFramework.System.Text from 1.3.36 to 1.3.42</br>Bumps nanoFramework.System.Threading from 1.1.50 to 1.1.52</br>Bumps nanoFramework.TestFramework from 3.0.73 to 3.0.75</br>
[version update]

### :warning: This is an automated update. :warning:
