### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.WiFi.nuspec
+++ b/MakoIoT.Device.Services.WiFi.nuspec
@@ -22,7 +22,7 @@
       <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
       <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.131" />
+      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.133" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
       <dependency id="nanoFramework.System.Net" version="1.11.43" />
       <dependency id="nanoFramework.System.Text" version="1.3.42" />

--- a/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
+++ b/src/MakoIoT.Device.Services.WiFi/MakoIoT.Device.Services.WiFi.nfproj
@@ -44,8 +44,8 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.131.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.131\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.133.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.133\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.96.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.96\lib\System.IO.Streams.dll</HintPath>

--- a/src/MakoIoT.Device.Services.WiFi/packages.config
+++ b/src/MakoIoT.Device.Services.WiFi/packages.config
@@ -5,7 +5,7 @@
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.131" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.133" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.43" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.System.Device.Wifi from 1.5.131 to 1.5.133</br>
[version update]

### :warning: This is an automated update. :warning:
